### PR TITLE
Fix PDF's with uppercase file extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,7 @@ export default class PDF2Pic {
    * @returns {Mixed} file status
    */
   isValidPDF(pdf_path) {
-    if (path.extname(path.basename(pdf_path)) !== '.pdf') {
+    if (path.extname(path.basename(pdf_path)).toLowerCase() !== '.pdf') {
       throw new Error('File supplied is not a valid PDF')
     }
 


### PR DESCRIPTION
This is a quick fix for PDF's with upper case or mixed case extensions. But detection if a file is a PDF should be better performed on the file data. PDF's mostly start with `%PDF`, but why not use a standard solution as PDFJS or allready used gm to load the pdf and then see if it throws an error or not.