### PR TITLE
Fixed bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default class PDF2Pic {
             return reject(error)
           }
 
-          return resolve(data.replace(/^[\w\W]+?1/, "1"))
+          return resolve(data.replace(/^[\w\W]*?1/, "1"))
         })
       } else {
         image.identify((error, data) => {


### PR DESCRIPTION
Fixing the bug regarding convertBulk with -1 on pdfs larger than 10 pages. At the moment it ignores pages till 10th page. Thats because of the regexp.

You can best visualize this by checking https://regexr.com/ with the following :
"1 2 3 4 5 6 7 8 9 10 11 12 13 14" - without quotes in the text
/^[\w\W]+?1/                                - the current rule

You will see it matches everything till 0. This, combined with the fact that it replaces with 1, it will cut all the pages till 10. Using this rule /^[\w\W]*?1/  will prevent that. However, I only made the rule with the least amount of possible changes. In my opinion the rule is kinda weird as it is. 