### PR TITLE
drop node 16 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 18
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 18
           registry-url: https://registry.npmjs.org
       - run: |
           sudo apt-get update

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     name: Node.js ${{ matrix.node-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18, 20, 22]
 
     name: Node.js ${{ matrix.node-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install GraphicsMagick and Ghostscript
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphicsmagick ghostscript
       - run: npm install
-      - uses: paambaati/codeclimate-action@v5
+      - uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/chai": "^4.3.5",
     "@types/gm": "^1.25.1",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^16.18.39",
+    "@types/node": "^18.19.50",
     "@types/rimraf": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",
@@ -44,7 +44,7 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "repository": {
     "type": "git",
@@ -78,6 +78,9 @@
   },
   "homepage": "https://github.com/yakovmeister/pdf2image#readme",
   "lint-staged": {
-    "*.{js,ts}": ["prettier --write", "eslint --fix"]
+    "*.{js,ts}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf2pic",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A utility for converting pdf to image formats. Supports different outputs: directly to file, base64 or buffer.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -199,8 +199,8 @@ This is deprecated and will be removed in the next major version.
   
 | pdf2pic version | node version     |
 |-----------------|------------------|
-| 1.4.0           | < 14.x           |
-| 2.1.4, 2.2.4    | >= 14.x          |
+| 1.4.0           | < 10.x           |
+| 2.1.4, 2.2.4    | >= 10.x          |
 | 3.1.1           | >= 14.x          |
 | >= 3.1.2        | >= 18.x          |
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ A utility for converting pdf to image, base64 or buffer format.
 
 ## Prerequisites
 
-* node >= 14.x 
+* node >= 18.x 
 * graphicsmagick
 * ghostscript
 

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,15 @@ Following are the options that can be passed on the pdf2pic api:
 
 The parameter can also be a boolean, if `true` then the response type will be `base64` and if `false` then the response type will be `image`. 
 This is deprecated and will be removed in the next major version.
+  
+## Version Compatibility  
+  
+| pdf2pic version | node version     |
+|-----------------|------------------|
+| 1.4.0           | < 14.x           |
+| 2.1.4, 2.2.4    | >= 14.x          |
+| 3.1.1           | >= 14.x          |
+| >= 3.1.2        | >= 18.x          |
 
 ## Contributing
 * Fork it (https://github.com/yakovmeister/pdf2image/fork)


### PR DESCRIPTION
Dropping node 16 support as it has already reached it's EOL.