### PR TITLE
fix: 220 - upgrade gm dep to fix cross-spawn vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "gm": "^1.25.0"
+    "gm": "^1.25.1"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^4.0.4",
@@ -78,6 +78,9 @@
   },
   "homepage": "https://github.com/yakovmeister/pdf2image#readme",
   "lint-staged": {
-    "*.{js,ts}": ["prettier --write", "eslint --fix"]
+    "*.{js,ts}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
This fixes https://github.com/yakovmeister/pdf2image/issues/220. The new version of `gm` simply upgrades the `cross-spawn` dependency, it doesn't have any breaking changes.

Moreover, `gm` has been sunset and actually archived: https://github.com/aheckmann/gm, it'd be great to move to another package.