### PR TITLE
Add `.units("PixelsPerInch")` to set proper DPI metadata in output images

### DIFF
--- a/src/graphics.ts
+++ b/src/graphics.ts
@@ -41,6 +41,7 @@ export class Graphics {
   public gmBaseCommand(stream: fs.ReadStream, filename: string): gm.State {
     return this.gm(stream, filename)
       .density(this.density, this.density)
+      .units("PixelsPerInch")
       .resize(this.width, this.height, this.preserveAspectRatio ? '^' : '!')
       .quality(this.quality)
       .compress(this.compression);


### PR DESCRIPTION
This PR adds `.units("PixelsPerInch")` to the image generation process to make sure the output images include proper DPI metadata.

Without this, the images don't reflect the density value set in the options. This can cause issues with OCR, printing, or any process that depends on DPI information.

The change is small, safe, and compatible with both ImageMagick and GraphicsMagick.